### PR TITLE
rename to hhd-adjustor for consistency

### DIFF
--- a/hhd-adjustor.spec
+++ b/hhd-adjustor.spec
@@ -1,7 +1,7 @@
-Name:           adjustor
+Name:           hhd-adjustor
 Version:        2.1.3
 Release:        1%{?dist}
-Summary:        Adjustor, a userspace program for managing the TDP of handheld devices.
+Summary:        HHD Adjustor, a userspace program for managing the TDP of handheld devices.
 
 License:        GPL-3.0-or-later
 URL:            https://github.com/hhd-dev/adjustor


### PR DESCRIPTION
I'm adding the hhd copr repositories directly into https://github.com/Nobara-Project/rpm-sources as submodules so that we can  better keep up with changes upstream per discussion here: https://github.com/Nobara-Project/rpm-sources/issues/23. I'm requesting renaming adjustor to hhd-adjustor to keep in uniform with the other two hhd packages (and so I dont forget what it's for)